### PR TITLE
make Optional nil-safe

### DIFF
--- a/optional.go
+++ b/optional.go
@@ -9,16 +9,13 @@ import (
 	"reflect"
 )
 
-// emptyOptional is a sentinel value for empty optionals.
-var emptyOptional = &Optional{}
-
 type (
 	// ActionFunc is the type of funcs invoked by IfPresent and IfPresentOrElse
-	// if an *Optional has a value.
+	// if an Optional has a value.
 	ActionFunc func(interface{})
 
 	// EmptyActionFunc is the type of funcs type invoked by IfPresentOrElse if
-	// an *Optional has no value.
+	// an Optional has no value.
 	EmptyActionFunc func()
 
 	// MapFunc is the type of funcs invoked by FlatMap and Map on the optional
@@ -39,20 +36,20 @@ type Optional struct {
 	value interface{}
 }
 
-// Empty returns an empty *Optional.
-func Empty() *Optional {
-	return emptyOptional
+// Empty returns an empty Optional.
+func Empty() Optional {
+	return Optional{}
 }
 
 // Equals returns true if other is equal to o. Equality is implied if:
 // 1) other is o (pointer equality)
-// 2) other and o are both of type *Optional and have the same value.
-func (o *Optional) Equals(other interface{}) bool {
+// 2) other and o are both of type Optional and have the same value.
+func (o Optional) Equals(other interface{}) bool {
 	if other == o {
 		return true
 	}
 
-	opt, ok := other.(*Optional)
+	opt, ok := other.(Optional)
 	if !ok {
 		return false
 	}
@@ -61,9 +58,9 @@ func (o *Optional) Equals(other interface{}) bool {
 }
 
 // Filter matches the optional value (if present) against predicate and returns
-// an *Optional describing the matched value, otherwise returns an empty
-// *Optional.
-func (o *Optional) Filter(predicate PredicateFunc) *Optional {
+// an Optional describing the matched value, otherwise returns an empty
+// Optional.
+func (o Optional) Filter(predicate PredicateFunc) Optional {
 	if o.IsEmpty() || predicate(o.value) {
 		return o
 	}
@@ -72,11 +69,11 @@ func (o *Optional) Filter(predicate PredicateFunc) *Optional {
 }
 
 // FlatMap applies the mapper func to the optional value (if present) and
-// returns a new *Optional wrapping the result, otherwise returns an empty
-// *Optional. If result itself is already an *Optional, it will not be wrapped
-// again but instead returned as is. Returning a nil *Optional from the mapper
+// returns a new Optional wrapping the result, otherwise returns an empty
+// Optional. If result itself is already an Optional, it will not be wrapped
+// again but instead returned as is. Returning a nil Optional from the mapper
 // func will cause a panic.
-func (o *Optional) FlatMap(mapper MapFunc) *Optional {
+func (o Optional) FlatMap(mapper MapFunc) Optional {
 	if o.IsEmpty() {
 		return o
 	}
@@ -87,6 +84,8 @@ func (o *Optional) FlatMap(mapper MapFunc) *Optional {
 			panic("optional.FlatMap: mapper func returned nil *Optional")
 		}
 
+		return *val
+	case Optional:
 		return val
 	default:
 		return OfNilable(val)
@@ -94,7 +93,7 @@ func (o *Optional) FlatMap(mapper MapFunc) *Optional {
 }
 
 // Get returns the optional value if present, otherwise it panics.
-func (o *Optional) Get() interface{} {
+func (o Optional) Get() interface{} {
 	if o.IsEmpty() {
 		panic("optional.Get: optional has no value")
 	}
@@ -102,15 +101,15 @@ func (o *Optional) Get() interface{} {
 	return o.value
 }
 
-// GetInto updates dst with the value of the *Optional if present, otherwise it
+// GetInto updates dst with the value of the Optional if present, otherwise it
 // panics. If dst is not a pointer or has a different type than the value
-// wrapped by the *Optional, GetInto will panic as well.
-func (o *Optional) GetInto(dst interface{}) {
+// wrapped by the Optional, GetInto will panic as well.
+func (o Optional) GetInto(dst interface{}) {
 	assignTo(o.Get(), dst, "optional.GetInto")
 }
 
 // IfPresent invokes action with the optional value if it is present.
-func (o *Optional) IfPresent(action ActionFunc) {
+func (o Optional) IfPresent(action ActionFunc) {
 	if o.IsPresent() {
 		action(o.value)
 	}
@@ -118,7 +117,7 @@ func (o *Optional) IfPresent(action ActionFunc) {
 
 // IfPresentOrElse invokes action with the optional value if it is present,
 // otherwise invokes emptyAction.
-func (o *Optional) IfPresentOrElse(action ActionFunc, emptyAction EmptyActionFunc) {
+func (o Optional) IfPresentOrElse(action ActionFunc, emptyAction EmptyActionFunc) {
 	if o.IsPresent() {
 		action(o.value)
 	} else {
@@ -128,19 +127,19 @@ func (o *Optional) IfPresentOrElse(action ActionFunc, emptyAction EmptyActionFun
 
 // IsEmpty returns true if no value is present, otherwise false. IsEmpty is the
 // opposite of IsPresent.
-func (o *Optional) IsEmpty() bool {
+func (o Optional) IsEmpty() bool {
 	return o.value == nil
 }
 
 // IsPresent returns true if a value is present, otherwise false. IsPresent is
 // the opposite of IsEmpty.
-func (o *Optional) IsPresent() bool {
+func (o Optional) IsPresent() bool {
 	return o.value != nil
 }
 
 // Map applies the mapper func to the optional value (if present) and returns a
-// new *Optional wrapping the result, otherwise returns an empty *Optional.
-func (o *Optional) Map(mapper MapFunc) *Optional {
+// new Optional wrapping the result, otherwise returns an empty Optional.
+func (o Optional) Map(mapper MapFunc) Optional {
 	if o.IsEmpty() {
 		return o
 	}
@@ -148,30 +147,30 @@ func (o *Optional) Map(mapper MapFunc) *Optional {
 	return OfNilable(mapper(o.value))
 }
 
-// Of returns an *Optional describing the given non-nil value. Panics if
+// Of returns an Optional describing the given non-nil value. Panics if
 // value is nil.
-func Of(value interface{}) *Optional {
+func Of(value interface{}) Optional {
 	if isNil(value) {
 		panic("optional.Of: value must not be nil")
 	}
 
-	return &Optional{value}
+	return Optional{value}
 }
 
-// OfNilable returns an *Optional describing the given value if it is non-nil,
-// otherwise returns an empty *Optional.
-func OfNilable(value interface{}) *Optional {
+// OfNilable returns an Optional describing the given value if it is non-nil,
+// otherwise returns an empty Optional.
+func OfNilable(value interface{}) Optional {
 	if isNil(value) {
 		return Empty()
 	}
 
-	return &Optional{value}
+	return Optional{value}
 }
 
-// Or returns the original *Optional if a value is present, otherwise returns
-// an *Optional wrapping the result of the supplier func. Panics if the
+// Or returns the original Optional if a value is present, otherwise returns
+// an Optional wrapping the result of the supplier func. Panics if the
 // supplier func returns nil.
-func (o *Optional) Or(supplier SupplyFunc) *Optional {
+func (o Optional) Or(supplier SupplyFunc) Optional {
 	if o.IsPresent() {
 		return o
 	}
@@ -179,9 +178,9 @@ func (o *Optional) Or(supplier SupplyFunc) *Optional {
 	return Of(supplier())
 }
 
-// OrElse returns the value of the original *Optional if present, otherwise
+// OrElse returns the value of the original Optional if present, otherwise
 // returns other.
-func (o *Optional) OrElse(other interface{}) interface{} {
+func (o Optional) OrElse(other interface{}) interface{} {
 	if o.IsPresent() {
 		return o.value
 	}
@@ -189,16 +188,16 @@ func (o *Optional) OrElse(other interface{}) interface{} {
 	return other
 }
 
-// OrElseInto updates dst with the value of the *Optional if present, otherwise
+// OrElseInto updates dst with the value of the Optional if present, otherwise
 // with the value of other. If dst is not a pointer or has a different type
-// than the value wrapped by the *Optional or other, OrElseInto will panic.
-func (o *Optional) OrElseInto(other, dst interface{}) {
+// than the value wrapped by the Optional or other, OrElseInto will panic.
+func (o Optional) OrElseInto(other, dst interface{}) {
 	assignTo(o.OrElse(other), dst, "optional.OrElseInto")
 }
 
-// OrElseGet returns the value of the original *Optional if present, otherwise
+// OrElseGet returns the value of the original Optional if present, otherwise
 // returns the value produced by the supplier func.
-func (o *Optional) OrElseGet(supplier SupplyFunc) interface{} {
+func (o Optional) OrElseGet(supplier SupplyFunc) interface{} {
 	if o.IsPresent() {
 		return o.value
 	}
@@ -206,17 +205,17 @@ func (o *Optional) OrElseGet(supplier SupplyFunc) interface{} {
 	return supplier()
 }
 
-// OrElseGetInto updates dst with the value of the *Optional if present,
+// OrElseGetInto updates dst with the value of the Optional if present,
 // otherwise with the value of produced by the supplier func. If dst is not a
-// pointer or has a different type than the value wrapped by the *Optional or
+// pointer or has a different type than the value wrapped by the Optional or
 // other, OrElseGetInto will panic.
-func (o *Optional) OrElseGetInto(supplier SupplyFunc, dst interface{}) {
+func (o Optional) OrElseGetInto(supplier SupplyFunc, dst interface{}) {
 	assignTo(o.OrElseGet(supplier), dst, "optional.OrElseGetInto")
 }
 
-// OrElsePanic returns the value of the original *Optional if present,
+// OrElsePanic returns the value of the original Optional if present,
 // otherwise panics with the given message.
-func (o *Optional) OrElsePanic(message string) interface{} {
+func (o Optional) OrElsePanic(message string) interface{} {
 	if o.IsPresent() {
 		return o.value
 	}
@@ -224,16 +223,16 @@ func (o *Optional) OrElsePanic(message string) interface{} {
 	panic(message)
 }
 
-// OrElsePanicInto updates dst with the value of the *Optional if present,
+// OrElsePanicInto updates dst with the value of the Optional if present,
 // otherwise panics with the given message. If dst is not a pointer or has a
-// different type than the value wrapped by the *Optional or other,
+// different type than the value wrapped by the Optional or other,
 // OrElsePanicInto will panic as well.
-func (o *Optional) OrElsePanicInto(message string, dst interface{}) {
+func (o Optional) OrElsePanicInto(message string, dst interface{}) {
 	assignTo(o.OrElsePanic(message), dst, "optional.OrElsePanicInto")
 }
 
 // String implements fmt.Stringer.
-func (o *Optional) String() string {
+func (o Optional) String() string {
 	if o.IsPresent() {
 		return fmt.Sprintf("Optional(%#v)", o.value)
 	}

--- a/optional_test.go
+++ b/optional_test.go
@@ -35,6 +35,11 @@ func TestFlatMap(t *testing.T) {
 		case "nil-optional":
 			var o *Optional
 			return o
+		case "ptr-optional":
+			return &Optional{}
+		case "zero-optional":
+			var o Optional
+			return o
 		default:
 			return nil
 		}
@@ -45,6 +50,8 @@ func TestFlatMap(t *testing.T) {
 	assert.Equal(t, Of("qux"), Of("baz").FlatMap(mapper))
 	assert.Equal(t, Empty(), Of("qux").FlatMap(mapper))
 	assert.Equal(t, Empty(), Empty().FlatMap(mapper))
+	assert.Equal(t, Empty(), Of("zero-optional").FlatMap(mapper))
+	assert.Equal(t, Empty(), Of("ptr-optional").FlatMap(mapper))
 	assert.PanicsWithValue(t, "optional.FlatMap: mapper func returned nil *Optional", func() {
 		Of("nil-optional").FlatMap(mapper)
 	})


### PR DESCRIPTION
The Optional API was by reference instead of by value which defeats the
purpose of it as it is not nil-safe. This commit fixes this but breaks
the public API.